### PR TITLE
Added ondestroy() event handler

### DIFF
--- a/src/android/CBLite.java
+++ b/src/android/CBLite.java
@@ -29,6 +29,7 @@ public class CBLite extends CordovaPlugin {
 	private boolean initFailed = false;
 	private int listenPort;
     private Credentials allowedCredentials;
+	private LiteListener listener;
 
 	/**
 	 * Constructor.
@@ -103,7 +104,7 @@ public class CBLite extends CordovaPlugin {
 	protected Manager startCBLite(Context context) {
 		Manager manager;
 		try {
-		        Manager.enableLogging(Log.TAG, Log.VERBOSE);
+		    Manager.enableLogging(Log.TAG, Log.VERBOSE);
 			Manager.enableLogging(Log.TAG_SYNC, Log.VERBOSE);
 			Manager.enableLogging(Log.TAG_QUERY, Log.VERBOSE);
 			Manager.enableLogging(Log.TAG_VIEW, Log.VERBOSE);
@@ -124,7 +125,7 @@ public class CBLite extends CordovaPlugin {
 
 	private int startCBLListener(int listenPort, Manager manager, Credentials allowedCredentials) {
 
-		LiteListener listener = new LiteListener(manager, listenPort, allowedCredentials);
+		listener = new LiteListener(manager, listenPort, allowedCredentials);
 		int boundPort = listener.getListenPort();
 		Thread thread = new Thread(listener);
 		thread.start();
@@ -140,5 +141,9 @@ public class CBLite extends CordovaPlugin {
 		System.out.println("CBLite.onPause() called");
 	}
 
+	public void onDestroy() {
+		System.out.println("CBLite.onDestroy() called");
+		listener.stop();
+	}
 
 }


### PR DESCRIPTION
If Cordova MainActivity stays in background for too long, Android may destroy it while the Couchbase Listener is kept alive due to Android Process lifecycle policies. The next time the Cordova MainActivity is opened, the Couchbase Listener will be created but in a different port (starting from default port 5984). If this behavior is repeated several times port usage will start to increment given that the Listeners won't be killed immediately. See Android log:

`10-28 12:32:55.390: W/LiteListener(23381): Could not bind to port: 5984.  Trying another port.
10-28 12:32:55.390: W/LiteListener(23381): Could not bind to port: 5985.  Trying another port.
10-28 12:32:55.390: W/LiteListener(23381): Could not bind to port: 5986.  Trying another port.
10-28 12:32:55.390: W/LiteListener(23381): Could not bind to port: 5987.  Trying another port.
10-28 12:32:55.390: W/LiteListener(23381): Could not bind to port: 5988.  Trying another port.
10-28 12:32:55.390: W/LiteListener(23381): Could not bind to port: 5989.  Trying another port.
10-28 12:32:55.390: W/LiteListener(23381): Could not bind to port: 5990.  Trying another port.
10-28 12:32:55.390: W/LiteListener(23381): Could not bind to port: 5991.  Trying another port.
10-28 12:32:55.390: W/LiteListener(23381): Could not bind to port: 5992.  Trying another port.
10-28 12:32:55.400: W/LiteListener(23381): Could not bind to port: 5993.  Trying another port.
10-28 12:32:55.400: W/LiteListener(23381): Could not bind to port: 5994.  Trying another port.
10-28 12:32:55.400: W/LiteListener(23381): Could not bind to port: 5995.  Trying another port.`

This may cause memory usage problems, but most important, a Listener could be bound to a port to which Chrome WebView won't have access to. 

In my case, I tested this by enabling the "Don't keep activities" property at Developer options and sending backgroud->foreground the app serveral times, When reaching port 6000, I got this error:

`http://8aed9bf7-aeb6-4c48-81dd-f41e139ee872:a76bdfa3-5291-4903-809e-391da00eb4a4@127.0.0.1:6000/database net::ERR_UNSAFE_PORT`

In order to solve this, I've implemented onDestroy() event. There I'll force to stop the listener. That way, either when the app is killed by Android or the user, Couchbase Listener will release the used port.
